### PR TITLE
Fix config loading

### DIFF
--- a/admin/src/components/Editor/index.js
+++ b/admin/src/components/Editor/index.js
@@ -32,7 +32,7 @@ const TinyEditor = ({ onChange, name, value }) => {
     }, []);
 
     return (
-        !loading ?
+        !loading && pluginConfig ?
             <Editor
                 apiKey={apiKey || ""}
                 value={value}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sklinet/strapi-plugin-tinymce",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sklinet/strapi-plugin-tinymce",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Replaces the default Strapi WYSIWYG editor with a customized build of TinyMCE editor.",
   "private": false,
   "keywords": [


### PR DESCRIPTION
Fix config loading when multiple TinyMCE editors appear in collections or dynamic zones.

PR should fix [issue no. 9](https://github.com/SKLINET/strapi-plugin-tinymce/issues/9)