### PR TITLE
fix: add uploaded content to current cursor location instead of end of file

### DIFF
--- a/admin/src/components/Editor/index.js
+++ b/admin/src/components/Editor/index.js
@@ -10,7 +10,9 @@ const TinyEditor = ({ onChange, name, value }) => {
     const [pluginConfig, setPluginConfig] = useState();
     const [apiKey, setApiKey] = useState("");
     const [loading, setLoading] = useState(true);
-    const uploadUrl = `${prefixFileUrlWithBackendUrl("/api/upload")}`;
+    const uploadUrl = `${prefixFileUrlWithBackendUrl("/upload")}`;
+
+    const token = localStorage.getItem("jwtToken");
 
     useEffect(() => {
         const getApiKey = async () => {
@@ -48,20 +50,15 @@ const TinyEditor = ({ onChange, name, value }) => {
                     images_upload_handler: async (blobInfo) => {
                       const formData = new FormData();
                       formData.append("files", blobInfo.blob());
-                      await fetch(uploadUrl, {
+                      const response = await fetch(uploadUrl, {
                         method: "POST",
                         headers: {
-                          Authorization: "Bearer ",
+                          Authorization: `Bearer ${token.indexOf('"') === 0 ? token.slice(1, -1) : token}`,
                         },
                         body: formData,
                       })
-                        .then((response) => {
-                          const result = response.json();
-                          console.log("result:", result);
-                        })
-                        .catch(function (err) {
-                          console.log("error:", err);
-                        });
+                        const result = await response.json();
+                        return result[0].url;
                     },
                   }}
             />

--- a/admin/src/components/Wysiwyg/index.js
+++ b/admin/src/components/Wysiwyg/index.js
@@ -28,12 +28,15 @@ const Wysiwyg = ({
         let newValue = value ? value : "";
 
         assets.map((asset) => {
-            if (asset.mime.includes("image")) {
-                const imgTag = `<p><img src="${asset.url}" alt="${asset.alt}"></img></p>`;
-                newValue = `${newValue}${imgTag}`;
+            if (asset.mime.includes('image') && typeof window !== 'undefined') {
+                const imgTag = `<p><img src="${asset.url}" caption="${asset.caption}" alt="${asset.alternativeText}"/></p>`;
+                window.tinymce.activeEditor.insertContent(imgTag);
+                newValue = window.tinymce.activeEditor.getContent();
             }
-            if (asset.mime.includes("video")) {
+
+            if (asset.mime.includes("video") && typeof window !== 'undefined') {
                 const videoTag = `<video><source src="${asset.url}" alt="${asset.alt}"</source></video>`;
+                window.tinymce.activeEditor.insertContent(videoTag);
                 newValue = `${newValue}${videoTag}`;
             }
         });


### PR DESCRIPTION
uploaded media from strapi media lib are added to the end of content instead of the current location of the cursor, 403/broken response returned on media upload (tested on strapi 4.6)