### PR TITLE
Add "setup" function to config 

### DIFF
--- a/admin/src/components/Editor/index.js
+++ b/admin/src/components/Editor/index.js
@@ -5,6 +5,7 @@ import { request } from "@strapi/helper-plugin";
 import pluginId from "../../pluginId";
 import taskRequests from "../../api/settings";
 import { prefixFileUrlWithBackendUrl } from "@strapi/helper-plugin";
+import { getSetup } from "../../utils";
 
 const TinyEditor = ({ onChange, name, value }) => {
     const [pluginConfig, setPluginConfig] = useState();
@@ -45,6 +46,7 @@ const TinyEditor = ({ onChange, name, value }) => {
                 outputFormat={pluginConfig?.outputFormat || "html"}
                 init={{
                     ...pluginConfig?.editorConfig,
+                    setup: getSetup,
                     images_upload_handler: async (blobInfo) => {
                       const formData = new FormData();
                       formData.append("files", blobInfo.blob());

--- a/admin/src/utils/get-setup.js
+++ b/admin/src/utils/get-setup.js
@@ -1,0 +1,14 @@
+let setupFunction = () => {};
+
+try {
+    const config = require('../../../../../config/plugins')();
+    const setupFun = config?.tinymce?.config?.editor?.editorConfig?.setup;
+
+    if (setupFun) {
+        setupFunction = setupFun;
+    }
+} catch (error) {
+    console.info('"setup" function for TinyMCE plugin is not defined, skipping');
+}
+
+export default setupFunction

--- a/admin/src/utils/index.js
+++ b/admin/src/utils/index.js
@@ -1,2 +1,3 @@
 export { default as getTrad } from "./get-trad";
 export { default as axiosInstance } from "./axiosInstance";
+export { default as getSetup } from "./get-setup";


### PR DESCRIPTION
Faced the same issue as https://github.com/SKLINET/strapi-plugin-tinymce/issues/31 but Strapi's config API doesn't allow functions to be passed.

The plugin now tries to read the `editorConfig`'s `setup` directly and use it for custom functionality.

Please consider merging, thanks! :)