### PR TITLE
Fix image upload and prefix

### DIFF
--- a/admin/src/utils/prefixFileUrlWithBackendUrl.ts
+++ b/admin/src/utils/prefixFileUrlWithBackendUrl.ts
@@ -1,12 +1,15 @@
-export const prefixFileUrlWithBackendUrl = (path: string, defaultDomain = 'http://localhost:1337') => {
-  if (path?.startsWith('http')) {
-    return path;
-  }
-  const url = process.env.BACKEND_URL;
+export const prefixFileUrlWithBackendUrl = (
+    path: string,
+    url = process.env.STRAPI_ADMIN_BACKEND_URL ?? process.env.BACKEND_URL ?? 'http://localhost:1337',
+) => {
+    if (path?.startsWith('http')) {
+        // Path is already a full URL. No prefix possible.
+        return path;
+    }
 
-  if (url) {
-    return url + path;
-  } else {
-    return defaultDomain + path;
-  }
+    if (url) {
+        return url + path;
+    } else {
+        return path;
+    }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sklinet/strapi-plugin-tinymce",
-    "version": "1.1.0",
+    "version": "1.1.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@sklinet/strapi-plugin-tinymce",
-            "version": "1.1.0",
+            "version": "1.1.6",
             "license": "MIT",
             "dependencies": {
                 "@strapi/design-system": "^2.0.0-rc.11",
@@ -370,6 +370,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
             "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+            "dev": true,
             "dependencies": {
                 "@emotion/memoize": "^0.8.1"
             }
@@ -377,7 +378,8 @@
         "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+            "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+            "dev": true
         },
         "node_modules/@emotion/memoize": {
             "version": "0.9.0",
@@ -6338,20 +6340,6 @@
                 "typedoc": ">=0.24.0"
             }
         },
-        "node_modules/@strapi/types/node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
-            "peer": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
         "node_modules/@strapi/typescript-utils": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-5.1.1.tgz",
@@ -7379,7 +7367,7 @@
             "version": "18.3.0",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
             "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "@types/react": "*"
             }
@@ -7435,7 +7423,8 @@
         "node_modules/@types/stylis": {
             "version": "4.2.5",
             "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
-            "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+            "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+            "dev": true
         },
         "node_modules/@types/through": {
             "version": "0.0.33",
@@ -8608,6 +8597,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
             "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -9246,20 +9236,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/cookies": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-            "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "depd": "~2.0.0",
-                "keygrip": "~1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/copyfiles": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
@@ -9470,6 +9446,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
             "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -9529,6 +9506,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
             "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+            "dev": true,
             "dependencies": {
                 "camelize": "^1.0.0",
                 "css-color-keywords": "^1.0.0",
@@ -13191,41 +13169,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/koa": {
-            "version": "2.13.4",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.4.tgz",
-            "integrity": "sha512-43zkIKubNbnrULWlHdN5h1g3SEKXOEzoAlRsHOTFpnlDu8JlAOZSMJBLULusuXRequboiwJcj5vtYXKB3k7+2g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "accepts": "^1.3.5",
-                "cache-content-type": "^1.0.0",
-                "content-disposition": "~0.5.2",
-                "content-type": "^1.0.4",
-                "cookies": "~0.8.0",
-                "debug": "^4.3.2",
-                "delegates": "^1.0.0",
-                "depd": "^2.0.0",
-                "destroy": "^1.0.4",
-                "encodeurl": "^1.0.2",
-                "escape-html": "^1.0.3",
-                "fresh": "~0.5.2",
-                "http-assert": "^1.3.0",
-                "http-errors": "^1.6.3",
-                "is-generator-function": "^1.0.7",
-                "koa-compose": "^4.1.0",
-                "koa-convert": "^2.0.0",
-                "on-finished": "^2.3.0",
-                "only": "~0.0.2",
-                "parseurl": "^1.3.2",
-                "statuses": "^1.5.0",
-                "type-is": "^1.6.16",
-                "vary": "^1.1.2"
-            },
-            "engines": {
-                "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
-            }
-        },
         "node_modules/koa-body": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/koa-body/-/koa-body-6.0.1.tgz",
@@ -13453,43 +13396,6 @@
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
-            }
-        },
-        "node_modules/koa/node_modules/http-errors": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-            "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": ">= 1.5.0 < 2",
-                "toidentifier": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/koa/node_modules/http-errors/node_modules/depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/koa/node_modules/statuses": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/koa2-ratelimit": {
@@ -14288,6 +14194,7 @@
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
             "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -15385,7 +15292,8 @@
         "node_modules/picocolors": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
+            "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -16320,7 +16228,8 @@
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true
         },
         "node_modules/prebuild-install": {
             "version": "7.1.2",
@@ -16754,6 +16663,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -16804,6 +16714,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -16816,6 +16727,7 @@
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "dev": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -17906,7 +17818,8 @@
         "node_modules/shallowequal": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+            "dev": true
         },
         "node_modules/sharp": {
             "version": "0.32.6",
@@ -18272,6 +18185,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18546,6 +18460,7 @@
             "version": "6.1.13",
             "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.13.tgz",
             "integrity": "sha512-M0+N2xSnAtwcVAQeFEsGWFFxXDftHUD7XrKla06QbpUMmbmtFBMMTcKWvFXtWxuD5qQkB8iU5gk6QASlx2ZRMw==",
+            "dev": true,
             "dependencies": {
                 "@emotion/is-prop-valid": "1.2.2",
                 "@emotion/unitless": "0.8.1",
@@ -18572,12 +18487,14 @@
         "node_modules/styled-components/node_modules/@emotion/unitless": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+            "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+            "dev": true
         },
         "node_modules/styled-components/node_modules/postcss": {
             "version": "8.4.38",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
             "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -18604,12 +18521,14 @@
         "node_modules/styled-components/node_modules/stylis": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
-            "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
+            "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+            "dev": true
         },
         "node_modules/styled-components/node_modules/tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "dev": true
         },
         "node_modules/stylis": {
             "version": "4.2.0",
@@ -19153,7 +19072,7 @@
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
             "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/server/src/controllers/admin.ts
+++ b/server/src/controllers/admin.ts
@@ -1,0 +1,28 @@
+import { Context } from 'koa';
+
+export default {
+    async uploadImage(ctx: Context) {
+        const file = Array.isArray(ctx.request.files.files) ? ctx.request.files.files[0] : ctx.request.files.files;
+
+        if (!file) {
+            return ctx.badRequest('No file uploaded');
+        }
+
+        try {
+            const [createdFile] = await strapi.plugins.upload.services.upload.upload({
+                data: {
+                    fileInfo: {
+                        name: file.originalFilename,
+                        caption: '',
+                        alternativeText: '',
+                    },
+                },
+                files: file,
+            });
+
+            ctx.body = { location: createdFile.url };
+        } catch (error) {
+            ctx.internalServerError(`Image upload failed ${error?.message || error?.toString()}`);
+        }
+    },
+};

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -1,9 +1,11 @@
-"use strict";
+'use strict';
 
+import admin from './admin';
 import config from './config';
 import settings from './settings';
 
 export default {
+    admin,
     config,
     settings,
 };

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,0 +1,13 @@
+import { Route } from '@strapi/types/dist/core';
+
+export default {
+    routes: [
+        {
+            method: 'POST',
+            path: '/uploadImage',
+            handler: 'admin.uploadImage',
+            // Enforce admin authentication
+            config: { auth: { scope: ['admin::isAuthenticatedAdmin'] } },
+        },
+    ] as Route[],
+};

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,7 +1,9 @@
+import admin from './admin';
 import config from './config';
 import settings from './settings';
 
 export default {
+    admin,
     config,
     settings,
 };


### PR DESCRIPTION
- Image upload needs to go to the plugin's own controller in order to successfully authenticate to the server.
- The prefix should allow a custom URL env variable to be passed (`STRAPI_ADMIN_BACKEND_URL`), fallback to the ingrained URL env variable (`BACKEND_URL`), and if that's not available for some reason, fall back to the default URL (`'http://localhost:1337'`).

Fixes #52 